### PR TITLE
tcp-client ignore hostname parameter: fixed

### DIFF
--- a/lib/tcp-client.js
+++ b/lib/tcp-client.js
@@ -7,7 +7,7 @@ const net = require('net');
 module.exports = function(mx, port, hostname) {
   let obj = new EventEmitter();
   mx.on('connection', stream => {
-    let client = net.connect({port: port, hostname: hostname}, socket => {
+    let client = net.connect( port, hostname, socket => {
       obj.emit('connection', socket, stream);
     });
     stream.pipe(client).pipe(stream);


### PR DESCRIPTION
I have fixed lib/tcp-client.js line 10.
It seems that parameter `hostname` would be ignored in this way. So I have fixed it based on this spec.

https://nodejs.org/api/net.html#socketconnect

That would be appreciated to merge my pull request. Thanks for advance.