### PR TITLE
`options.tcpHostname` should be `options.tcpHost`.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -30,7 +30,7 @@ module.exports = function(options) {
       ws.on('close', () => clearInterval(timer));
     }
     if (options.remote) {
-      let client = tcpClient(mx, options.tcpPort, options.tcpHostname);
+      let client = tcpClient(mx, options.tcpPort, options.tcpHost);
       client.on('connection', data => obj.emit('tcp-connection', data));
       client.on('close', () => obj.emit('tcp-close'));
       client.on('error', err => obj.emit('error', err));


### PR DESCRIPTION
I appreciated for merging my fist pull request.

I see one side-effect-bug found(`options.tcpHostname` should be `options.tcpHost` in client.js L.33) in current code. So I have fixed it, and create new pull request for this. 

Please merge this one. Thanks for advance.